### PR TITLE
launch in foreground to allow k8s to restart if crashing

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -31,4 +31,4 @@ do
 done
 echo "Postgres is ready"
 
-node ${EXPLORER_APP_ROOT}/main.js name - hyperledger-explorer &
+node ${EXPLORER_APP_ROOT}/main.js name - hyperledger-explorer


### PR DESCRIPTION
Some times the peer node can take quite a long time to complete the bootstrap and activate the discovery service. This causes the explorer project to crash. but because it's launched in the background, k8s doesn't know it needs to be restarted. changing it to launch in the foreground should fix that

Reference: https://kaleidoio.zendesk.com/agent/tickets/11672