### PR TITLE
Add missing dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
 		"fabric nodesdk"
 	],
 	"dependencies": {
+		"@mapbox/node-pre-gyp": "^1.0.10",
 		"ajv": "^5.5.2",
 		"app-root-path": "^2.0.1",
 		"asn1.js": "^5.0.1",


### PR DESCRIPTION
Fix launch errors from the latest IT runs:

```console
jimzhang(k8s: netplane-it.photic.io) $ kubectl logs -n zzv70yht8p zzv70yht8p-zzooiedb6h-fabric-node-0 -c explorer

> hyperledger-explorer@1.1.8 app-start /opt/explorer
> ./start.sh

************************************************************************************
**************************** Hyperledger Explorer **********************************
************************************************************************************
Waiting for config file
Config file found
localhost:5432 - accepting connections
Postgres is ready
internal/modules/cjs/loader.js:965
  throw err;
  ^

Error: Cannot find module '@mapbox/node-pre-gyp'
Require stack:
- /opt/explorer/node_modules/bcrypt/bcrypt.js
- /opt/explorer/app/platform/fabric/service/UserService.js
- /opt/explorer/app/platform/fabric/Platform.js
- /opt/explorer/app/platform/PlatformBuilder.js
- /opt/explorer/app/Explorer.js
- /opt/explorer/app/main.js
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:962:15)
    at Function.Module._load (internal/modules/cjs/loader.js:838:27)
    at Module.require (internal/modules/cjs/loader.js:1022:19)
    at require (internal/modules/cjs/helpers.js:72:18)
    at Object.<anonymous> (/opt/explorer/node_modules/bcrypt/bcrypt.js:3:18)
    at Module._compile (internal/modules/cjs/loader.js:1118:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1138:10)
    at Module.load (internal/modules/cjs/loader.js:982:32)
    at Function.Module._load (internal/modules/cjs/loader.js:875:14)
    at Module.require (internal/modules/cjs/loader.js:1022:19) {
  code: 'MODULE_NOT_FOUND',
  requireStack: [
    '/opt/explorer/node_modules/bcrypt/bcrypt.js',
    '/opt/explorer/app/platform/fabric/service/UserService.js',
    '/opt/explorer/app/platform/fabric/Platform.js',
    '/opt/explorer/app/platform/PlatformBuilder.js',
    '/opt/explorer/app/Explorer.js',
    '/opt/explorer/app/main.js'
  ]
}
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! hyperledger-explorer@1.1.8 app-start: `./start.sh`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the hyperledger-explorer@1.1.8 app-start script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /root/.npm/_logs/2023-05-17T20_38_40_619Z-debug.log
```